### PR TITLE
Fix issue with prediction horizon and regression components

### DIFF
--- a/R/bayesianStateSpace.R
+++ b/R/bayesianStateSpace.R
@@ -29,8 +29,6 @@ bayesianStateSpace <- function(jaspResults, dataset, options) {
     options[["predictionHorizon"]] <- 0L
 
   # read dataset
-
-
   dataset <- .bstsReadData(options,ready)
   # error checking
   .bstsErrorHandling(dataset, options)
@@ -135,15 +133,13 @@ bayesianStateSpace <- function(jaspResults, dataset, options) {
     jaspResults[["bstsMainContainer"]]$dependOn(.bstsModelDependencies())
   }
 
-  if(is.null(jaspResults[["bstsMainContainer"]][["bstsModelResults"]])) {
+  if (is.null(jaspResults[["bstsMainContainer"]][["bstsModelResults"]])) {
     bstsModelResultsState <- createJaspState()
 
     bstsModelResults <- .bstsResultsHelper(dataset,options)
     bstsModelResultsState$object <- bstsModelResults
     jaspResults[["bstsMainContainer"]][["bstsModelResults"]] <- bstsModelResultsState
   }
-
-
 
   if (is.null(jaspResults[["bstsMainContainer"]][["bstsModelPredictions"]]) && options$predictionHorizon > 0) {
     bstsResults <- jaspResults[["bstsMainContainer"]][["bstsModelResults"]]$object
@@ -159,21 +155,10 @@ bayesianStateSpace <- function(jaspResults, dataset, options) {
 
 .bstsResultsHelper <- function(dataset,options) {
 
-  #y     <- dataset[,options[["dependent"]]]
-
-  #data <- data.frame(y=y)
-
-
   predictors = NULL
   if (length(options$covariates)>0|length(options$factors) >0)
     predictors <- .bstsGetPredictors(options$modelTerms)
   formula = .bstsGetFormula(dependent=dataset[,options[["dependent"]]],predictors = predictors,options)
-
-  #for(predictor in predictors){
-  #  data[[predictor]] <- dataset[dataset[,options[["dependent"]]]]
-  #}
-
-
 
   ss   <- list()
   #AddAr

--- a/R/bayesianStateSpace.R
+++ b/R/bayesianStateSpace.R
@@ -141,11 +141,11 @@ bayesianStateSpace <- function(jaspResults, dataset, options) {
 
 
 
-  if (is.null(jaspResults[["bstsMainContainer"]][["bstsModelPredictions"]]) & options$predictionHorizon >0) {
+  if (is.null(jaspResults[["bstsMainContainer"]][["bstsModelPredictions"]]) && options$predictionHorizon > 0) {
     bstsResults <- jaspResults[["bstsMainContainer"]][["bstsModelResults"]]$object
     bstsModelPredictionsState <- createJaspState()
     bstsModelPredictionsState$dependOn(.bstsPredictionDependencies())
-    bstsPredictionResults <- bsts::predict.bsts(object = bstsResults,horizon=options$predictionHorizon,seed = options$seed)
+    bstsPredictionResults <- bsts::predict.bsts(object = bstsResults, horizon = options$predictionHorizon, seed = options$seed, newdata = dataset)
     bstsModelPredictionsState$object <- bstsPredictionResults
     jaspResults[["bstsMainContainer"]][["bstsModelPredictions"]] <- bstsModelPredictionsState
   }

--- a/R/bayesianStateSpace.R
+++ b/R/bayesianStateSpace.R
@@ -24,6 +24,10 @@ bayesianStateSpace <- function(jaspResults, dataset, options) {
   ready <- (options$dependent != "" && any(options[c("checkboxAr","checkboxLocalLevel","checkboxLocalLinearTrend","checkboxSemiLocalLinearTrend")]==TRUE,length(options$seasonalities)>0))
   # Init options: add variables to options to be used in the remainder of the analysis
 
+  # ensure the prediction horizon is 0 whenever there are covariates or factors
+  if (length(options[["covariates"]]) > 0L || length(options[["factors"]]) > 0L)
+    options[["predictionHorizon"]] <- 0L
+
   # read dataset
 
 
@@ -145,7 +149,7 @@ bayesianStateSpace <- function(jaspResults, dataset, options) {
     bstsResults <- jaspResults[["bstsMainContainer"]][["bstsModelResults"]]$object
     bstsModelPredictionsState <- createJaspState()
     bstsModelPredictionsState$dependOn(.bstsPredictionDependencies())
-    bstsPredictionResults <- bsts::predict.bsts(object = bstsResults, horizon = options$predictionHorizon, seed = options$seed, newdata = dataset)
+    bstsPredictionResults <- bsts::predict.bsts(object = bstsResults, horizon = options$predictionHorizon, seed = options$seed)
     bstsModelPredictionsState$object <- bstsPredictionResults
     jaspResults[["bstsMainContainer"]][["bstsModelPredictions"]] <- bstsModelPredictionsState
   }

--- a/inst/qml/bayesianStateSpace.qml
+++ b/inst/qml/bayesianStateSpace.qml
@@ -11,8 +11,8 @@ Form
 
 		AvailableVariablesList	{ name: "allVariablesList" }
 		AssignedVariablesList	{ name: "dependent";	title: qsTr("Dependent Variable");	suggestedColumns: ["scale"];	singleVariable: true}
-		AssignedVariablesList	{ name: "covariates";	title: qsTr("Covariates");			suggestedColumns: ["scale"];	allowedColumns: ["scale"]	}
-		AssignedVariablesList 	{ name: "factors";		title: qsTr("Factors");				allowedColumns: ["ordinal", "nominal", "nominalText"]		}
+		AssignedVariablesList	{ name: "covariates";	title: qsTr("Covariates");			suggestedColumns: ["scale"];	allowedColumns: ["scale"];	id: covariates	}
+		AssignedVariablesList 	{ name: "factors";		title: qsTr("Factors");				allowedColumns: ["ordinal", "nominal", "nominalText"];		id: factors		}
 		AssignedVariablesList	{ name: "dates";		title: qsTr("Time");				suggestedColumns: ["nominal"];	singleVariable: true		}
 	}
 
@@ -359,6 +359,7 @@ Form
 			{
 				name: "predictionHorizon"
 				label: qsTr("Horizon")
+				enabled: covariates.count === 0 && factors.count === 0
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1825

also adds some cosmetic improvements to the same function. From the helpfile of `?bsts::predict.bsts` (emphasis mine):

> a vector, matrix, or data frame containing the predictor variables to use in making the prediction. <b>This is only required if object contains a regression component.</b> If a data frame ...

So just an oversight I guess. I wasn't able to test this outside of jaspTools (I have some issues building Jasp on my laptop), but I'll do that tomorrow or so.