### PR TITLE
Added empty table if no input and default model component

### DIFF
--- a/inst/qml/bayesianStateSpace.qml
+++ b/inst/qml/bayesianStateSpace.qml
@@ -122,7 +122,7 @@ Form
 			name: "localLevelComponent"
 			label: qsTr("Add local level component")
 			id: checkLocalLevel
-			checked: false
+			checked: true
 			Layout.columnSpan: 2
 			//CheckBox
 			//{


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/2223
An empty table is now shown when no variable is selected.
Additionally, I enabled the "local level" component by defeault and added a footnote regarding this. Because otherwise the user selects the depedent variable and has to open the "Model Component" section and select a component to run the model - which is not in line with the other modules.