### PR TITLE
sets AR lag number to at least one

### DIFF
--- a/inst/qml/bayesianStateSpace.qml
+++ b/inst/qml/bayesianStateSpace.qml
@@ -95,6 +95,7 @@ Form
 						name: "lags"
 						label: qsTr("No. of lags")
 						fieldWidth: 40
+						min: 1
 					defaultValue: 1
 					}
 				}
@@ -102,7 +103,7 @@ Form
 				{
 					value: "auto"; label: qsTr("Automatic")
 					columns: 1
-					DoubleField { name: "maxLags";	label: qsTr("Maximal lags");	fieldWidth: 40; 	defaultValue: 1;}
+					DoubleField { name: "maxLags";	label: qsTr("Maximal lags");	fieldWidth: 40; 	defaultValue: 1; min:1}
 				}
 			}
 


### PR DESCRIPTION
- fixes error that occurred when lags of autoregressive component were set to 0 by changing minimum value to 1
- closes https://github.com/jasp-stats/jasp-test-release/issues/2459